### PR TITLE
do not use repository name as alias (bnc#551014)

### DIFF
--- a/package/yast2-metapackage-handler.changes
+++ b/package/yast2-metapackage-handler.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Nov  3 14:45:57 UTC 2014 - lslezak@suse.cz
+
+- do not use repository name as alias, it must be unique, let
+  pkg-bindings create it (bnc#551014)
+- 3.1.4
+
+-------------------------------------------------------------------
 Wed Jun  4 06:47:46 UTC 2014 - pgajdos@suse.com
 
 - OneClickInstallCLI: /sbin/YaST -> /usr/sbin/yast

--- a/package/yast2-metapackage-handler.spec
+++ b/package/yast2-metapackage-handler.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-metapackage-handler
-Version:        3.1.3
+Version:        3.1.4
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/OneClickInstallWorkerFunctions.rb
+++ b/src/modules/OneClickInstallWorkerFunctions.rb
@@ -111,7 +111,6 @@ module Yast
             "enabled"     => true,
             "autorefresh" => true,
             "name"        => OneClickInstall.GetRepositoryName(new_url),
-            "alias"       => OneClickInstall.GetRepositoryName(new_url),
             "base_urls"   => [new_url]
           }
           srcid = Pkg.RepositoryAdd(repoData)


### PR DESCRIPTION
it must be unique, let pkg-bindings create it
- 3.1.4

`pkg-bindings` create an unique alias if it is missing or is empty (https://github.com/yast/yast-pkg-bindings/blob/master/src/Source_Create.cc#L410)
