### PR TITLE
Removal of HTML inline styles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ Makefile.am.common
 .dep
 tmp.*
 *.log
+/doc/autodocs
+/.yardoc

--- a/.yardopts
+++ b/.yardopts
@@ -1,0 +1,7 @@
+--no-private
+--markup markdown
+--protected
+--readme README.md
+--output-dir ./doc/autodocs
+--files *.md
+src/**/*.rb

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # YaST - The One Click Installer Module #
 
-[![Travis Build](https://travis-ci.org/yast/yast-metapackage.svg?branch=master)](https://travis-ci.org/yast/yast-metapackage)
-[![Jenkins Build](http://img.shields.io/jenkins/s/https/ci.opensuse.org/yast-metapackage-master.svg)](https://ci.opensuse.org/view/Yast/job/yast-metapackage-master/)
+[![Travis Build](https://travis-ci.org/yast/yast-metapackage-handler.svg?branch=master)](https://travis-ci.org/yast/yast-metapackage-handler)
+[![Jenkins Build](http://img.shields.io/jenkins/s/https/ci.opensuse.org/yast-metapackage-handler-master.svg)](https://ci.opensuse.org/view/Yast/job/yast-metapackage-handler-master/)
 

--- a/package/yast2-metapackage-handler.changes
+++ b/package/yast2-metapackage-handler.changes
@@ -1,6 +1,12 @@
 -------------------------------------------------------------------
 Mon Nov  3 14:45:57 UTC 2014 - lslezak@suse.cz
 
+- don't use inline html styles when including package metadata
+- 4.0.0
+
+-------------------------------------------------------------------
+Mon Nov  3 14:45:57 UTC 2014 - lslezak@suse.cz
+
 - do not use repository name as alias, it must be unique, let
   pkg-bindings create it (bnc#551014)
 - 3.1.4

--- a/package/yast2-metapackage-handler.changes
+++ b/package/yast2-metapackage-handler.changes
@@ -1,5 +1,5 @@
 -------------------------------------------------------------------
-Mon Nov  3 14:45:57 UTC 2014 - lslezak@suse.cz
+Tue Feb  13 11:46:30 UTC 2018 - lelcp@protonmail.com
 
 - don't use inline html styles when including package metadata
 - 4.0.0

--- a/package/yast2-metapackage-handler.spec
+++ b/package/yast2-metapackage-handler.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-metapackage-handler
-Version:        3.1.4
+Version:        4.0.0
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/OneClickInstallWidgets.rb
+++ b/src/modules/OneClickInstallWidgets.rb
@@ -118,7 +118,7 @@ module Yast
         Ops.add(
           Ops.add(
             Ops.add(
-              "<body bgcolor=\"White\">",
+              "<body>",
               HTML.Heading(_("Repository Description:"))
             ),
             NewLinesToRichText(description)
@@ -177,7 +177,7 @@ module Yast
         Ops.add(
           Ops.add(
             Ops.add(
-              "<body bgcolor=\"White\">",
+              "<body>",
               HTML.Heading(_("Package Description:"))
             ),
             NewLinesToRichText(description)
@@ -229,7 +229,7 @@ module Yast
         Ops.add(
           Ops.add(
             Ops.add(
-              "<body bgcolor=\"White\">",
+              "<body>",
               HTML.Heading(_("Package Description:"))
             ),
             NewLinesToRichText(description)
@@ -355,7 +355,7 @@ module Yast
       end
 
       summaryStr = Ops.add(
-        "<body bgcolor=\"White\">",
+        "<body>",
         HTML.Colorize(
           _(
             "If you continue, the following changes will be made to your system:"
@@ -454,7 +454,7 @@ module Yast
         :Value,
         Ops.add(
           Ops.add(
-            "<body bgcolor=\"White\">",
+            "<body>",
             HTML.Para(NewLinesToRichText(description))
           ),
           "</body>"
@@ -481,7 +481,7 @@ module Yast
       failedPatterns = deep_copy(failedPatterns)
       failedPackages = deep_copy(failedPackages)
       statusStr = Ops.add(
-        "<body bgcolor=\"White\">",
+        "<body>",
         HTML.Heading(_("Software installation"))
       )
 


### PR DESCRIPTION
HTML inline styles cause problematic behavior in case of GTK themes

![White](https://user-images.githubusercontent.com/30577011/35896157-3a2f9bd6-0bbb-11e8-8f33-79cca39c1a20.png)

YaST in this case should handle either both font color and background color or neither. I opted for neither, as I don't like being blinded by big white textboxes when using dark themes.

Changed screen looks like this:
![Dark](https://user-images.githubusercontent.com/30577011/35896308-dc0e0db6-0bbb-11e8-8442-4a524a28284d.png)