### PR TITLE
Fix Dockerfile and .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ config.sub
 configure
 configure.ac
 depcomp
+doc/
 install-sh
 *.pot
 libtool
@@ -27,3 +28,4 @@ Makefile.am.common
 .dep
 tmp.*
 *.log
+.yardoc/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM yastdevel/ruby:sle12-sp5
 
+RUN zypper --gpg-auto-import-keys --non-interactive in --no-recommends \
+    perl-XML-XPath
 
 COPY . /usr/src/app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM yastdevel/ruby:sle12-sp5
 
-RUN zypper --gpg-auto-import-keys --non-interactive in --no-recommends \
+RUN zypper --non-interactive in --no-recommends \
     perl-XML-XPath
 
 COPY . /usr/src/app


### PR DESCRIPTION
## Problem

Travis [is complaining](https://travis-ci.org/yast/yast-metapackage-handler/builds/560978562) because of 

* the new [Perl syntax check](https://github.com/yast/docker-yast-ruby/commit/7dd9c8cab22fa7f7d516d9664c091f19e06673be)
  ```
  Can't locate XML/XPath.pm in @INC (you may need to install the XML::XPath module)
  ```
* an outdated .gitignore

## Solution

* Install the `perl-XML-XPath` package in the Docker image, to fulfill the Perl dependencies
* Update the .gitignore file