### PR TITLE
Do not crash if .y2usersettings is missing (bsc#1173781)

### DIFF
--- a/package/yast2-metapackage-handler.changes
+++ b/package/yast2-metapackage-handler.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Jul 21 10:57:39 UTC 2020 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Fixed a crash when ~/.y2usersettings is missing (bsc#1173781)
+- 4.3.0
+
+-------------------------------------------------------------------
 Fri Nov 15 10:38:42 UTC 2019 - Steffen Winterfeldt <snwint@suse.com>
 
 - rewrite YMP file parsing (bsc#1138638)

--- a/package/yast2-metapackage-handler.spec
+++ b/package/yast2-metapackage-handler.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-metapackage-handler
-Version:        4.1.1
+Version:        4.3.0
 Release:        0
 Summary:        YaST2 - Easy Installation of Add-on RPMs using Metapackages
 License:        GPL-2.0-or-later

--- a/src/modules/UserSettings.rb
+++ b/src/modules/UserSettings.rb
@@ -4,6 +4,8 @@ require "yast"
 
 module Yast
   class UserSettingsClass < Module
+    include Yast::Logger
+
     def main
 
       Yast.import "XML"
@@ -36,11 +38,7 @@ module Yast
         @FILENAME
       )
       Builtins.y2debug("Reading UserSettings from %1", @FILENAME)
-      @settings = Convert.convert(
-        XML.XMLToYCPFile(@FILENAME),
-        :from => "map <string, any>",
-        :to   => "map <string, map <string, any>>"
-      )
+      @settings = read_xml_file(@FILENAME)
 
       nil
     end
@@ -104,6 +102,19 @@ module Yast
     publish :function => :GetIntegerValue, :type => "integer (string, string)"
     publish :function => :GetBooleanValue, :type => "boolean (string, string)"
     publish :function => :SetValue, :type => "boolean (string, string, any)"
+
+  private
+
+    # Turns the content of the specified XML file into a hash
+    #
+    # @param path [String] name of the XML file
+    # @return [Hash] empty hash if the file does not exists or cannot be processed
+    def read_xml_file(path)
+      XML.XMLToYCPFile(path)
+    rescue RuntimeError => e
+      log.debug "Using empty hash for #{path}: #{e.inspect}"
+      {}
+    end
   end
 
   UserSettings = UserSettingsClass.new


### PR DESCRIPTION
## Problem

The one-click-installer is crashing when this file is not present or is invalid: `~/.y2usersettings`. See [bsc#1173781](https://bugzilla.suse.com/show_bug.cgi?id=1173781) and its duplicates.

That's caused by a recent change in the API of `YaST::XML.XMLToYCPFile`. It used to return `nil` when the XML file cannot be read, now it throws an exception.

## Solution

This pull request includes proper handling of the new exception. The execution continues and the `.y2usersettings` file is properly created at a later stage.

## Testing

All combinations tested manually.