### PR TITLE
Sync changelog with OBS

### DIFF
--- a/package/yast2-metapackage-handler.changes
+++ b/package/yast2-metapackage-handler.changes
@@ -5,6 +5,12 @@ Tue Jul 21 10:57:39 UTC 2020 - Ancor Gonzalez Sosa <ancor@suse.com>
 - 4.3.0
 
 -------------------------------------------------------------------
+Fri Jan 24 10:02:03 UTC 2020 - Steffen Winterfeldt <snwint@suse.com>
+
+- remove obsolete patch 103.diff
+- remove obsolete patch SLE.diff
+
+-------------------------------------------------------------------
 Fri Nov 15 10:38:42 UTC 2019 - Steffen Winterfeldt <snwint@suse.com>
 
 - rewrite YMP file parsing (bsc#1138638)


### PR DESCRIPTION
## Problem

This OBS request includes a changelog entry that is not in the git repository. https://build.opensuse.org/request/show/766789

As a result, subsequent auto-generated submit requests like [sr#822070](https://build.opensuse.org/request/show/822070) cause weird effects.

## Solution

Add the ghost changelog entry to the git repository as well.